### PR TITLE
Initialized github action

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,7 @@
+name: Checkup bot build and deploy to AWS
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:


### PR DESCRIPTION
GitHub action skeleton must be in master with a workflow dispatch trigger in order to test manually on a branch. This PR creates the action skeleton for use in by other branch (3).